### PR TITLE
fix(netlify): configurar base, build y publish para deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+[build]
+  # La app vive en mi_portafolio/, no en la raíz del repo
+  base = "mi_portafolio"
+  command = "pnpm build"
+  # Relativo a base -> mi_portafolio/dist
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "22"
+
+# Fallback SPA: cualquier ruta no encontrada cae al index ya prerenderizado
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Problema

El sitio en producción fallaba con:
- `main.tsx:1 Failed to load module script... MIME type "application/octet-stream"`
- `404` de `main.tsx` y `manifest.json`

## Causa raíz

La app vive en `mi_portafolio/`, no en la raíz del repo, y **no existía `netlify.toml`**. Netlify publicaba el directorio fuente y servía el `index.html` de desarrollo (con `<script src="/src/main.tsx">`) en lugar del build de `dist/`. Por eso el navegador recibía TS/octet-stream y no encontraba `manifest.json`.

El build local (`dist/`) es correcto: referencia `/assets/app-*.js` e incluye `manifest.json`.

## Solución

Añadir `netlify.toml` en la raíz:
- `base = "mi_portafolio"`
- `command = "pnpm build"`
- `publish = "dist"`
- `NODE_VERSION = "22"`
- Fallback SPA `/* -> /index.html` (200)

## Nota

Revisar en Netlify UI (Build & deploy) que los campos *base*/*publish* manuales estén vacíos, para que mande el `netlify.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)