### PR TITLE
fix: restaurar skeleton + normalizar URLs de imagenes/CV de Strapi

### DIFF
--- a/mi_portafolio/src/App.tsx
+++ b/mi_portafolio/src/App.tsx
@@ -5,7 +5,7 @@ import { queryClient } from "./lib/queryClient";
 import { Header } from "./components/Header";
 import { Hero } from "./components/Hero";
 import { SEO } from "./components/SEO";
-import { SectionSkeleton } from "./components/ui/Skeleton";
+import { SectionSkeleton } from "./components/ui/skeleton";
 
 const AboutSection = lazy(() =>
   import("./components/About").then((m) => ({ default: m.About }))

--- a/mi_portafolio/src/components/ui/skeleton.tsx
+++ b/mi_portafolio/src/components/ui/skeleton.tsx
@@ -1,0 +1,21 @@
+import Skeleton from "@mui/material/Skeleton";
+
+type SectionSkeletonProps = {
+  title: string;
+  isAltBackground?: boolean;
+};
+
+export const SectionSkeleton = ({ title, isAltBackground }: SectionSkeletonProps) => (
+  <section
+    aria-label={`Cargando ${title}`}
+    className={`py-20 px-4 ${isAltBackground ? "bg-muted/30" : ""}`}
+  >
+    <div className="container mx-auto space-y-4 px-7" role="status">
+      <Skeleton variant="text" width={192} height={28} />
+      <div className="space-y-3">
+        <Skeleton variant="text" height={20} />
+        <Skeleton variant="rectangular" height={72} />
+      </div>
+    </div>
+  </section>
+);


### PR DESCRIPTION
Arregla el build roto y los assets que apuntaban al localhost viejo.

## 1. Build roto (TS2307)
El componente `SectionSkeleton` se había perdido por una trampa de casing en macOS. Se recrea como `skeleton.tsx` (minúscula, según convención de `ui/`) y se ajusta el import en `App.tsx`.

## 2. Imágenes no se visualizan
`assetUrl` concatenaba ciegamente `BASE + url`. Si Strapi devolvía URLs absolutas con `localhost:1337`, el resultado quedaba roto. Ahora `assetUrl`:
- relativa (`/uploads/..`) → antepone `BASE`
- absoluta a `localhost`/`127.0.0.1` → reescribe el path sobre `BASE`
- absoluta a otro host (CDN/S3) → la deja intacta

## 3. CV redirige a localhost viejo
`data.cvUrl` se usaba crudo. Ahora pasa por `assetUrl`, normalizándolo al Strapi de producción.

## Verificación
`pnpm build` (tsc -b + vite-react-ssg build) pasa sin errores. ✅

> Nota: si en Strapi el campo `cvUrl` está guardado literalmente como `http://localhost:1337/...`, el código lo reescribe al host de producción, pero el archivo debe existir en el Strapi de prod (misma ruta `/uploads/...`). Idealmente actualizar también el valor en el CMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)